### PR TITLE
Add git and ssh package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ENV GOSS_VERSION 0.3.15
 ENV ROADWORKER_VERSION 0.5.14
 
 RUN set -ex \
+ && apk add --no-cache \
+    git \
+    openssh \
  && apk add --no-cache --virtual .builddeps \
     curl \
     build-base \
@@ -21,4 +24,3 @@ RUN set -ex \
  && curl -L https://github.com/aelsabbahy/goss/releases/download/v${GOSS_VERSION}/goss-linux-amd64 -o /usr/local/bin/goss \
  && chmod +x /usr/local/bin/goss \
  && apk del .builddeps
-


### PR DESCRIPTION
- CircleCI workflow says "Either git or ssh (required by git to clone
  through SSH) is not installed in the image. "
  -   https://app.circleci.com/pipelines/github/mapk0y/dns-k0y.org/1/workflows/4cf91815-ee6d-43f5-bad7-d03684c72378/jobs/114